### PR TITLE
#### Added support for Java 1.8 and Apache Ant 1.9 ####

### DIFF
--- a/.openshift/action_hooks/start
+++ b/.openshift/action_hooks/start
@@ -4,10 +4,37 @@ cd $OPENSHIFT_DATA_DIR
 
 if [ -d $OPENSHIFT_DATA_DIR/tomcat8 ]
 then
+    # Java 1.8 set env
+    export PATH=$OPENSHIFT_DATA_DIR/jdk1.8.0_20/bin:$PATH
+    export JAVA_HOME=$OPENSHIFT_DATA_DIR/jdk1.8.0_20/
+
+    # Ant 1.9 set env
+    ANT_HOME=$OPENSHIFT_DATA_DIR/apache-ant-1.9.6
+    ANT_OPTS="-Xms256M -Xmx512M"
+    PATH=$PATH:$HOME/bin:$ANT_HOME/bin
+    export ANT_HOME ANT_OPTS PATH
+
 	cd tomcat8/bin
 	./startup.sh
     exit 0
 else
+    # Java 1.8 Installation and Configuration
+    cd $OPENSHIFT_DATA_DIR
+    wget --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u20-b26/jdk-8u20-linux-x64.tar.gz
+    tar -zxf jdk-8u20-linux-x64.tar.gz
+    export PATH=$OPENSHIFT_DATA_DIR/jdk1.8.0_20/bin:$PATH
+    export JAVA_HOME=$OPENSHIFT_DATA_DIR/jdk1.8.0_20/
+
+    # Apache Ant Installation and Configuration
+    cd $OPENSHIFT_DATA_DIR
+    wget https://www.apache.org/dist/ant/binaries/apache-ant-1.9.6-bin.zip
+    unzip apache-ant-1.9.6-bin.zip
+    ANT_HOME=$OPENSHIFT_DATA_DIR/apache-ant-1.9.6
+    ANT_OPTS="-Xms256M -Xmx512M"
+    PATH=$PATH:$HOME/bin:$ANT_HOME/bin
+    export ANT_HOME ANT_OPTS PATH
+
+    cd $OPENSHIFT_DATA_DIR
 	mkdir -p source dependencies
 	cd source/
 	git clone https://github.com/apache/tomcat.git

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
+
 ## Quickstart to run Apache Tomcat 8 on OpenShift##
+
+#### Added support for Java 1.8 and Apache Ant 1.9 ####
 
 Apache Tomcat 8 adds support for lots of Java EE 7 features like WebSockets, Servlet 3.1, JSP 2.3, Expression Language 3.0, as well as additional Tomcat-specific features. There is not much documentation around all that will be added in Apache Tomcat 8 but I found these presentation [slides](http://archive.apachecon.com/eu2012/presentations/06-Tuesday/RN-ApacheEE/aceu-2012-tomcat-8-preview.pdf) useful.  Samples running Apache Tomcat 8 on OpenShift can be found at http://tomcat8-cix.rhcloud.com/ and http://tomcat8-cix.rhcloud.com/examples
 


### PR DESCRIPTION
# Release Notes

Added Support for 
- Java 1.8
- Apache Ant 1.9

Apache Ant support is required as, ant is not available in few OpenShift servers
